### PR TITLE
feat[#241]: jwt refresh token -> redis에 저장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build Spring Boot
         run: ./gradlew clean bootJar
-
+`
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build Spring Boot
         run: ./gradlew clean bootJar
-`
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ logs/
 
 ### search datas ###
 Board/
+
+### AI Agent Memories ###
+.claude

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.github.loki4j:loki-logback-appender:1.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:4.3.1'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: cra-mysql-dev
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cra_dev
+    ports:
+      - "3306:3306"
+    volumes:
+      - cra_mysql_dev_data:/var/lib/mysql
+
+  redis:
+    image: redis:7
+    container_name: cra-redis-dev
+    ports:
+      - "6379:6379"
+
+volumes:
+  cra_mysql_dev_data:
+    driver: local

--- a/src/main/java/com/handong/cra/crawebbackend/auth/domain/CustomUserDetails.java
+++ b/src/main/java/com/handong/cra/crawebbackend/auth/domain/CustomUserDetails.java
@@ -9,10 +9,15 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 
 @Getter
-@RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
     private final User user;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+        authorities = user.getRoles().getAuthorities();
+    }
 
     @Override
     public String getPassword() {
@@ -46,7 +51,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return user.getRoles().getAuthorities();
+        return authorities;
     }
 
     public Long getUserId(){

--- a/src/main/java/com/handong/cra/crawebbackend/auth/repository/DbRefreshTokenRepository.java
+++ b/src/main/java/com/handong/cra/crawebbackend/auth/repository/DbRefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.handong.cra.crawebbackend.auth.repository;
+
+import com.handong.cra.crawebbackend.auth.domain.RefreshToken;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@ConditionalOnProperty(name = "jwt.refresh-store", havingValue = "db")
+public class DbRefreshTokenRepository implements RefreshTokenRepository {
+    private final RefreshTokenJpaRepository jpaRepository;
+
+    public DbRefreshTokenRepository(RefreshTokenJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public void save(RefreshToken refreshToken) {
+        jpaRepository.save(refreshToken);
+    }
+
+    @Override
+    public RefreshToken findByToken(String token) {
+        return jpaRepository.findByRefreshToken(token);
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        jpaRepository.deleteAllByUserId(userId);
+    }
+}

--- a/src/main/java/com/handong/cra/crawebbackend/auth/repository/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/handong/cra/crawebbackend/auth/repository/RedisRefreshTokenRepository.java
@@ -1,0 +1,68 @@
+package com.handong.cra.crawebbackend.auth.repository;
+
+import com.handong.cra.crawebbackend.auth.domain.RefreshToken;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@ConditionalOnProperty(name = "jwt.refresh-store", havingValue = "redis")
+public class RedisRefreshTokenRepository implements RefreshTokenRepository{
+    private static final String KEY_PREFIX = "refresh_token:";
+    private static final String USER_KEY_PREFIX = "refresh_token:user:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Long refreshExpiration;
+
+    public RedisRefreshTokenRepository(
+            RedisTemplate<String, String> redisTemplate,
+            @Value("${jwt.refresh-expiration}") Long refreshExpiration
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.refreshExpiration = refreshExpiration;
+    }
+
+    @Override
+    public void save(RefreshToken refreshToken) {
+        String tokenKey = KEY_PREFIX + refreshToken.getRefreshToken();
+        String userKey = USER_KEY_PREFIX + refreshToken.getUserId();
+
+        redisTemplate.opsForValue().set(
+                userKey,
+                refreshToken.getRefreshToken(),
+                refreshExpiration,
+                TimeUnit.MILLISECONDS
+        );
+
+        redisTemplate.opsForValue().set(
+                tokenKey,
+                String.valueOf(refreshToken.getUserId()),
+                refreshExpiration,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    @Override
+    public RefreshToken findByToken(String token) {
+        String key = KEY_PREFIX + token;
+
+        String userIdStr = redisTemplate.opsForValue().get(key);
+
+        return RefreshToken.of(Long.parseLong(userIdStr), token);
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        String userKey = USER_KEY_PREFIX + userId;
+        String token = redisTemplate.opsForValue().get(userKey);
+
+        String tokenKey = KEY_PREFIX + token;
+
+        if (token != null) {
+            redisTemplate.delete(tokenKey);
+        }
+        redisTemplate.delete(userKey);
+    }
+}

--- a/src/main/java/com/handong/cra/crawebbackend/auth/repository/RefreshTokenJpaRepository.java
+++ b/src/main/java/com/handong/cra/crawebbackend/auth/repository/RefreshTokenJpaRepository.java
@@ -1,0 +1,9 @@
+package com.handong.cra.crawebbackend.auth.repository;
+
+import com.handong.cra.crawebbackend.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
+    RefreshToken findByRefreshToken(String refreshToken);
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/handong/cra/crawebbackend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/handong/cra/crawebbackend/auth/repository/RefreshTokenRepository.java
@@ -1,9 +1,9 @@
 package com.handong.cra.crawebbackend.auth.repository;
 
 import com.handong.cra.crawebbackend.auth.domain.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    RefreshToken findByRefreshToken(String refreshToken);
+public interface RefreshTokenRepository {
+    void save(RefreshToken refreshToken);
+    RefreshToken findByToken(String token);
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/handong/cra/crawebbackend/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/handong/cra/crawebbackend/auth/service/CustomUserDetailsService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +15,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         final User user = userRepository.findByUsername(username);
         if (user == null) {

--- a/src/main/java/com/handong/cra/crawebbackend/config/ReddisonConfig.java
+++ b/src/main/java/com/handong/cra/crawebbackend/config/ReddisonConfig.java
@@ -1,0 +1,35 @@
+package com.handong.cra.crawebbackend.config;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.ConstantDelay;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class ReddisonConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port)
+                .setConnectionPoolSize(10)       // 커넥션 풀 최대 크기
+                .setConnectionMinimumIdleSize(5) // 최소 유지 커넥션
+                .setConnectTimeout(3000)         // 연결 타임아웃 (ms)
+                .setRetryAttempts(3)             // 락 획득 실패 시 재시도 횟수
+                .setRetryDelay(new ConstantDelay(Duration.ofMillis(1500)));         // 재시도 간격 (ms)
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/handong/cra/crawebbackend/config/RedisConfig.java
+++ b/src/main/java/com/handong/cra/crawebbackend/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.handong.cra.crawebbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        template.setDefaultSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/handong/cra/crawebbackend/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/handong/cra/crawebbackend/util/JwtAuthenticationFilter.java
@@ -62,9 +62,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String parseJwt(final HttpServletRequest request) {
         String token = request.getHeader("Authorization");
         if (token != null && token.startsWith("Bearer ")) {
-            log.info(token);
             token = token.substring(7);
-            log.info(token);
             return token;
         }
         return null;

--- a/src/main/java/com/handong/cra/crawebbackend/util/JwtTokenProvider.java
+++ b/src/main/java/com/handong/cra/crawebbackend/util/JwtTokenProvider.java
@@ -3,15 +3,11 @@ package com.handong.cra.crawebbackend.util;
 import com.handong.cra.crawebbackend.auth.domain.RefreshToken;
 import com.handong.cra.crawebbackend.auth.dto.ReissueTokenDto;
 import com.handong.cra.crawebbackend.auth.dto.TokenDto;
-import com.handong.cra.crawebbackend.auth.dto.response.ResTokenDto;
 import com.handong.cra.crawebbackend.auth.repository.RefreshTokenRepository;
-import com.handong.cra.crawebbackend.exception.auth.AuthInvalidTokenException;
-import com.handong.cra.crawebbackend.exception.auth.AuthTokenExpiredException;
 import com.handong.cra.crawebbackend.exception.user.UserNotFoundException;
 import com.handong.cra.crawebbackend.user.domain.User;
 import com.handong.cra.crawebbackend.user.domain.UserRoleSet;
 import com.handong.cra.crawebbackend.user.repository.UserRepository;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -19,7 +15,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -67,13 +62,13 @@ public class JwtTokenProvider {
         final Long userId = user.getId();
         final UserRoleSet roles = user.getRoles();
         final String refreshToken = generateToken(userId, refreshExpiration, roles);
-        final RefreshToken newRefreshToken = refreshTokenRepository.save(new RefreshToken(userId, refreshToken));
-        return TokenDto.of(newRefreshToken.getUserId(), null, newRefreshToken.getRefreshToken());
+        refreshTokenRepository.save(new RefreshToken(userId, refreshToken));
+        return TokenDto.of(userId, null, refreshToken);
     }
 
     @Transactional
     public TokenDto reissueToken(final ReissueTokenDto reissueTokenDto) {
-        final RefreshToken savedToken = refreshTokenRepository.findByRefreshToken(reissueTokenDto.getRefreshToken());
+        final RefreshToken savedToken = refreshTokenRepository.findByToken(reissueTokenDto.getRefreshToken());
         if (savedToken == null) { // 만료되었는지 검사
             return TokenDto.of(null, "expired", "expired");
         }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -18,6 +18,9 @@ management:
       exposure:
         include: health, prometheus
 
+jwt:
+  refresh-store: redis
+
 site:
   frontend:
     url: https://cra206.org


### PR DESCRIPTION
- redis 채택 이유: 빠른 조회 속도, ttl 자동 만료, 강제 만료 처리, 중복 로그인 방어(토큰 덮어씌우기)
- Strategy pattern 이용해서 redis/db 전환할 수 있게 구현하였음(application.yml에서 변경가능)
- [hotfix] UserDetailService에서 user role 불러올 때 transactional이 적용되지 않아 lazy 불가능해서 오류 발생하였음 -> transactional 적용